### PR TITLE
Update Ruby version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew bundle install --no-upgrade
 
 ...or manually:
 
-* Ruby 3.1.0
+* Ruby 3.1.2
 * [libpq](https://www.postgresql.org/docs/9.5/libpq.html) - `brew install libpq`
     * `libpg` is needed to use the native `pg` gem without Rosetta on M1 macs
 * [postgresql](https://www.postgresql.org) - `brew install postgresql` [Note: PostgreSQL 13+ is required]


### PR DESCRIPTION
I just forked the project and reading the `README.md` I saw that the version needed was `3.1.0` so I installed that and then ran `bin/setup` and it fails saying I need `3.1.2`. So I'm just updating the README.md to match with the current version.

## Pull request checklist

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)
